### PR TITLE
upgrading h5py version to recent since needed by tensorflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+# Auxiliary directories
 .cache/
+.vscode/
 
 # compiled python files
 *.pyc

--- a/pyilastik/ilastik_storage_version_01.py
+++ b/pyilastik/ilastik_storage_version_01.py
@@ -117,14 +117,14 @@ class IlastikStorageVersion01(object):
         self.skip_image = skip_image
 
         try:
-            version = self.f.get('/Input Data/StorageVersion')[()].decode()
+            version = self.f.get('/Input Data/StorageVersion')[()]
         except AttributeError:
             # for ilastik release > 1.3.0
             version = self.f.get('/Input Data/StorageVersion')[()]
         assert version == '0.2'
 
     def ilastik_version(self):
-        version_str = self.f.get('ilastikVersion')[()].decode()
+        version_str = self.f.get('ilastikVersion')[()]
         return int(version_str.replace('.', '')[:3])
 
     def __iter__(self):
@@ -164,7 +164,7 @@ class IlastikStorageVersion01(object):
 
             path = self.f.get(
                 '/Input Data/infos/{lane}/Raw Data/filePath'.format(lane=lane))
-            path = path[()].decode()
+            path = path[()]
 
             path_list.append(path)
 
@@ -184,7 +184,7 @@ class IlastikStorageVersion01(object):
         lane = 'lane{:04}'.format(i)
         path = f.get(
             '/Input Data/infos/{lane}/Raw Data/filePath'.format(lane=lane))
-        path = path[()].decode()
+        path = path[()]
         original_path = path
 
         prediction = None  # TODO
@@ -419,7 +419,7 @@ class IlastikStorageVersion01(object):
         slice_list = []
         for block in self._get_blocks(item_index):
             slices = re.findall('([0-9]+):([0-9]+)',
-                                block.attrs['blockSlice'].decode('ascii'))
+                                block.attrs['blockSlice'])
             slice_list.append(slices)
 
         return np.array(slice_list).astype('int')

--- a/pyilastik/ilastik_version_05.py
+++ b/pyilastik/ilastik_version_05.py
@@ -21,7 +21,7 @@ class IlastikVersion05(object):
         f = self.f
         dset = f.get('/DataSets/dataItem{:02}'.format(i))
 
-        path = utils.basename(dset.attrs['fileName'].decode('ascii'))
+        path = utils.basename(dset.attrs['fileName'])
         img = np.array(dset.get('data')) if not self.skip_image else None
         labels = np.array(dset.get('labels/data'))
 

--- a/pyilastik/lib.py
+++ b/pyilastik/lib.py
@@ -18,7 +18,7 @@ def read_project(ilastik_file, image_path=None, prediction=False,
     version = f.get('/PixelClassification/StorageVersion')
     if version is not None:
         try:
-            version = version[()].decode()
+            version = version[()]
         except AttributeError:
             # for ilastik releases >1.3.0
             version = version[()]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-reqs = ['h5py==2.10.0',
+reqs = ['h5py>=2.10.0',
         'numpy>=1.12.1',
         'docopt>=0.6.2',
         'tifffile']
@@ -14,7 +14,7 @@ def readme():
 
 
 setup(name='pyilastik',
-      version='0.0.9',
+      version='0.1.0',
       description='Read ilastik labels in python',
       author='Manuel Schoelling, Christoph Moehl',
       author_email='manuel.schoelling@dzne.de, christoph.oliver.moehl@gmail.com',


### PR DESCRIPTION
yapic can only use tensorflow=2.4.3 due to h5py requirement.
With latest version h5py, yapic should be able to use latest version of tensorflow (2.6.0)